### PR TITLE
correction to CreateFile result check

### DIFF
--- a/test/asan/TestCases/Windows/bind_io_completion_callback.cc
+++ b/test/asan/TestCases/Windows/bind_io_completion_callback.cc
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
       OPEN_EXISTING,
       FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING | FILE_FLAG_OVERLAPPED,
       NULL);
-  if (!file)
+  if (file == INVALID_HANDLE_VALUE)
     return 2;
   if (!BindIoCompletionCallback(file, completion_callback, 0))
     return 3;


### PR DESCRIPTION
If the CreateFile fails, the return value is INVALID_HANDLE_VALUE, not 0
